### PR TITLE
feat: 비밀번호 변경 api 및 회원 탈퇴 validator 추가

### DIFF
--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -1,4 +1,10 @@
-const { createUser, loginUser, logoutUser, deleteUser: deleteUserService } = require("../services/user.service");
+const { 
+  createUser, 
+  loginUser, 
+  logoutUser, 
+  deleteUser: deleteUserService,
+  changeUserPassword 
+} = require("../services/user.service");
 
 
 // 회원가입 요청 처리 컨트롤러
@@ -72,5 +78,24 @@ async function deleteUser(req, res, next) {
   }
 }
 
-module.exports = { signup, login, logout, deleteUser };
+// 비밀번호 변경 요청 처리 컨트롤러
+async function changePassword(req, res, next) {
+  try {
+    // authMiddleware에서 추가한 req.user 객체에서 id를 가져옴
+    const { id} = req.user;
+    // req.body에서 현재 비밀번호와 새 비밀번호를 가져옴
+    const { currentPassword, newPassword } = req.body;
+
+    // 서비스 레이어 호출 -> DB에서 비밀번호 변경
+    await changeUserPassword(id, currentPassword, newPassword);
+
+    return res.status(200).json({
+      message: "비밀번호 변경 성공"
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { signup, login, logout, deleteUser, changePassword };
 

--- a/src/middlewares/validators/user.dto.js
+++ b/src/middlewares/validators/user.dto.js
@@ -59,6 +59,27 @@ const loginValidator = [
   }
 ];
 
+// 회원탈퇴 검증
+const deleteUserValidator = [
+  // password: 필수, 8~64자
+  body("password")
+    .isString().withMessage("비밀번호는 문자열이어야 합니다.")
+    .isLength({ min: 8, max: 64 }).withMessage("비밀번호는 8~64자입니다."),
+
+  // 검증 결과 처리
+  (req, res, next) => {
+    const errors = validationResult(req);
+    if(!errors.isEmpty()) {
+      return res.status(400).json({
+        state: 400,
+        code: "VALIDATION_ERROR",
+        errors: errors.array().map(e => ({ field: e.path, message: e.msg }))
+      });
+    }
+    next();
+  }
+];
+
 // 비밀번호 변경 검증
 const changePasswordValidator = [
   // currentPassword: 필수, 8~64자
@@ -85,4 +106,9 @@ const changePasswordValidator = [
   }
 ];
 
-module.exports = { signupValidator , loginValidator, changePasswordValidator };
+module.exports = { 
+  signupValidator, 
+  loginValidator, 
+  deleteUserValidator, 
+  changePasswordValidator 
+};

--- a/src/middlewares/validators/user.dto.js
+++ b/src/middlewares/validators/user.dto.js
@@ -59,4 +59,30 @@ const loginValidator = [
   }
 ];
 
-module.exports = { signupValidator , loginValidator };
+// 비밀번호 변경 검증
+const changePasswordValidator = [
+  // currentPassword: 필수, 8~64자
+  body("currentPassword")
+    .isString().withMessage("비밀번호는 문자열이어야 합니다.")
+    .isLength({ min: 8, max: 64 }).withMessage("비밀번호는 8~64자입니다."),
+
+  // newPassword: 필수, 8~64자
+  body("newPassword")
+    .isString().withMessage("비밀번호는 문자열이어야 합니다.")
+    .isLength({ min: 8, max: 64 }).withMessage("비밀번호는 8~64자입니다."), 
+    
+  // 검증 결과 처리
+  (req, res, next) => {
+    const errors = validationResult(req);
+    if(!errors.isEmpty()) {
+      return res.status(400).json({
+        state: 400,
+        code: "VALIDATION_ERROR",
+        errors: errors.array().map(e => ({ field: e.path, message: e.msg }))
+      });
+    }
+    next();
+  }
+];
+
+module.exports = { signupValidator , loginValidator, changePasswordValidator };

--- a/src/routes/user.routes.js
+++ b/src/routes/user.routes.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const router = express.Router();
-const { signup, login, logout, deleteUser } = require("../controllers/user.controller");
+const { signup, login, logout, deleteUser, changePassword } = require("../controllers/user.controller");
 const { signupValidator, loginValidator } = require("../middlewares/validators/user.dto");
 const authMiddleware = require("../middlewares/auth.js");
 
@@ -16,5 +16,8 @@ router.post("/logout", authMiddleware, logout);
 
 // DELETE /api/users/delete -> 회원 탈퇴
 router.delete("/delete", authMiddleware, deleteUser);
+
+// PUT /api/users/change-password -> 비밀번호 변경 
+router.put("/change-password", authMiddleware, changePassword);
 
 module.exports = router;

--- a/src/routes/user.routes.js
+++ b/src/routes/user.routes.js
@@ -1,7 +1,12 @@
 const express = require("express");
 const router = express.Router();
 const { signup, login, logout, deleteUser, changePassword } = require("../controllers/user.controller");
-const { signupValidator, loginValidator } = require("../middlewares/validators/user.dto");
+const { 
+    signupValidator, 
+    loginValidator,
+    deleteUserValidator,
+    changePasswordValidator
+} = require("../middlewares/validators/user.dto");
 const authMiddleware = require("../middlewares/auth.js");
 
 // POST /api/users/signup → 회원가입
@@ -10,14 +15,13 @@ router.post("/signup", signupValidator, signup);
 // POST /api/users/login -> 로그인
 router.post("/login", loginValidator, login);
 
-
 // POST /api/users/logout -> 로그아웃
 router.post("/logout", authMiddleware, logout);
 
 // DELETE /api/users/delete -> 회원 탈퇴
-router.delete("/delete", authMiddleware, deleteUser);
+router.delete("/delete", authMiddleware, deleteUserValidator, deleteUser);
 
 // PUT /api/users/change-password -> 비밀번호 변경 
-router.put("/change-password", authMiddleware, changePassword);
+router.put("/change-password", authMiddleware, changePasswordValidator, changePassword);
 
 module.exports = router;


### PR DESCRIPTION
# 작업 내용
- 비밀번호 변경 API 구현
- validator 추가(회원탈퇴 시, 비밀번호 변경 시 비밀번호 검증)
- 라우터 수정(회원탈퇴, 비밀번호 변경 시 validator 적용)
# 확인 사항
- 회원가입 시 규칙과 동일하게 비밀번호 변경 시에도 길이 제한(8~64자)
- 기존 비밀번호 불일치 시 INVALID_CURRENT_PASSWORD 반환