### PR TITLE
feat: 비밀번호 재설정 기능 추가 (이메일 발송, 토큰 검증, 재설정 API)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
         "mysql2": "^3.14.3",
+        "nodemailer": "^7.0.6",
         "sequelize": "^6.37.7"
       },
       "devDependencies": {
@@ -1219,6 +1220,15 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.6.tgz",
+      "integrity": "sha512-F44uVzgwo49xboqbFgBGkRaiMgtoBrBEWCVincJPK9+S9Adkzt/wXCLKbf7dxucmxfTI5gHGB+bEmdyzN6QKjw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.2",
     "mysql2": "^3.14.3",
+    "nodemailer": "^7.0.6",
     "sequelize": "^6.37.7"
   },
   "devDependencies": {

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -1,4 +1,10 @@
-const { createUser, loginUser, logoutUser, deleteUser: deleteUserService } = require("../services/user.service");
+const { 
+  createUser, 
+  loginUser, 
+  logoutUser, 
+  deleteUser: deleteUserService,
+  changeUserPassword 
+} = require("../services/user.service");
 
 
 // 회원가입 요청 처리 컨트롤러
@@ -72,5 +78,24 @@ async function deleteUser(req, res, next) {
   }
 }
 
-module.exports = { signup, login, logout, deleteUser };
+// 비밀번호 변경 요청 처리 컨트롤러
+async function changePassword(req, res, next) {
+  try {
+    // authMiddleware에서 추가한 req.user 객체에서 id를 가져옴
+    const { id} = req.user;
+    // req.body에서 현재 비밀번호와 새 비밀번호를 가져옴
+    const { currentPassword, newPassword } = req.body;
+
+    // 서비스 레이어 호출 -> DB에서 비밀번호 변경
+    await changeUserPassword(id, currentPassword, newPassword);
+
+    return res.status(200).json({
+      message: "비밀번호 변경 성공"
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { signup, login, logout, deleteUser, changePassword };
 

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -3,7 +3,9 @@ const {
   loginUser, 
   logoutUser, 
   deleteUser: deleteUserService,
-  changeUserPassword 
+  changeUserPassword,
+  requestPasswordReset,
+  resetUserPassword 
 } = require("../services/user.service");
 
 
@@ -82,7 +84,7 @@ async function deleteUser(req, res, next) {
 async function changePassword(req, res, next) {
   try {
     // authMiddleware에서 추가한 req.user 객체에서 id를 가져옴
-    const { id} = req.user;
+    const { id } = req.user;
     // req.body에서 현재 비밀번호와 새 비밀번호를 가져옴
     const { currentPassword, newPassword } = req.body;
 
@@ -97,5 +99,47 @@ async function changePassword(req, res, next) {
   }
 }
 
-module.exports = { signup, login, logout, deleteUser, changePassword };
+// 비밀번호 재설정 요청 처리 컨트롤러
+async function forgotPassword(req, res, next) {
+  try {
+    // req.body에서 이메일 가져옴
+    const { email } = req.body;
+
+    // 서비스 호출 -> resetToken 생성 및 이메일 발송
+    await requestPasswordReset(email);
+
+    return res.status(200).json({
+      message: "비밀번호 재설정 이메일이 전송되었습니다."
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// 비밀번호 재설정 처리 컨트롤러
+async function resetPassword(req, res, next) {
+  try {
+    // req.body에서 이메일, 토큰, 새 비밀번호 가져옴
+    const { email, token, newPassword } = req.body;
+
+    // 서비스 호출 -> 토큰 검증 후 DB 비밀번호 업데이트
+    await resetUserPassword(email, token, newPassword);
+
+    return res.status(200).json({
+      message: "비밀번호가 성공적으로 재설정되었습니다."
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { 
+  signup, 
+  login, 
+  logout,
+  deleteUser, 
+  changePassword,
+  forgotPassword,
+  resetPassword
+};
 

--- a/src/middlewares/validators/user.dto.js
+++ b/src/middlewares/validators/user.dto.js
@@ -1,5 +1,18 @@
 const { body, validationResult } = require("express-validator");
 
+// 공통 검증 결과 처리
+function handleValidationResult(req, res, next) {
+  const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
+        state: 400,
+        code: "VALIDATION_ERROR",
+        errors: errors.array().map(e => ({ field: e.path, message: e.msg }))
+      });
+    }
+  next();
+}
+
 // 회원가입 검증
 const signupValidator = [
   // email: 필수, 이메일 형식, 최대 120자  
@@ -20,17 +33,7 @@ const signupValidator = [
     .isLength({ min: 8, max: 64 }).withMessage("비밀번호는 8~64자입니다."),
 
   // 검증 결과 처리
-  (req, res, next) => {
-    const errors = validationResult(req);
-    if (!errors.isEmpty()) {
-      return res.status(400).json({
-        state: 400,
-        code: "VALIDATION_ERROR",
-        errors: errors.array().map(e => ({ field: e.path, message: e.msg }))
-      });
-    }
-    next();
-  }
+  handleValidationResult
 ];
 
 //로그인 검증
@@ -46,17 +49,7 @@ const loginValidator = [
     .isLength({ min: 8, max: 64 }).withMessage("비밀번호는 8~64자입니다."),
 
   // 검증 결과 처리
-  (req, res, next) => {
-    const errors = validationResult(req);
-    if(!errors.isEmpty()) {
-      return res.status(400).json({
-        state: 400,
-        code: "VALIDATION_ERROR",
-        errors: errors.array().map(e => ({ field: e.path, message: e.msg }))
-      });
-    }
-    next();
-  }
+  handleValidationResult
 ];
 
 // 회원탈퇴 검증
@@ -67,17 +60,7 @@ const deleteUserValidator = [
     .isLength({ min: 8, max: 64 }).withMessage("비밀번호는 8~64자입니다."),
 
   // 검증 결과 처리
-  (req, res, next) => {
-    const errors = validationResult(req);
-    if(!errors.isEmpty()) {
-      return res.status(400).json({
-        state: 400,
-        code: "VALIDATION_ERROR",
-        errors: errors.array().map(e => ({ field: e.path, message: e.msg }))
-      });
-    }
-    next();
-  }
+  handleValidationResult
 ];
 
 // 비밀번호 변경 검증
@@ -93,22 +76,47 @@ const changePasswordValidator = [
     .isLength({ min: 8, max: 64 }).withMessage("비밀번호는 8~64자입니다."), 
     
   // 검증 결과 처리
-  (req, res, next) => {
-    const errors = validationResult(req);
-    if(!errors.isEmpty()) {
-      return res.status(400).json({
-        state: 400,
-        code: "VALIDATION_ERROR",
-        errors: errors.array().map(e => ({ field: e.path, message: e.msg }))
-      });
-    }
-    next();
-  }
+  handleValidationResult
+];
+
+// 비밀번호 재설정 요청 검증
+const forgotPasswordValidator = [
+  // email: 필수, 이메일 형식, 최대 120자  
+  body("email")
+    .trim()
+    .isEmail().withMessage("유효한 이메일을 입력하세요.")
+    .isLength({ max: 120 }).withMessage("이메일은 최대 120자입니다."),
+
+  // 검증 결과 처리
+  handleValidationResult
+];
+
+// 비밀번호 재설정 완료 검증
+const resetPasswordValidator = [
+  // email: 필수, 이메일 형식, 최대 120자  
+  body("email")
+    .trim()
+    .isEmail().withMessage("유효한 이메일을 입력하세요.")
+    .isLength({ max: 120 }).withMessage("이메일은 최대 120자입니다."),
+
+  // token: 필수, 문자열
+  body("token")
+    .isString().withMessage("토큰은 문자열이어야 합니다."),
+
+  // newPassword: 필수, 8~64자
+  body("newPassword")
+    .isString().withMessage("비밀번호는 문자열이어야 합니다.")
+    .isLength({ min: 8, max: 64 }).withMessage("비밀번호는 8~64자입니다."),
+
+  // 검증 결과 처리
+  handleValidationResult
 ];
 
 module.exports = { 
   signupValidator, 
   loginValidator, 
   deleteUserValidator, 
-  changePasswordValidator 
+  changePasswordValidator,
+  forgotPasswordValidator,
+  resetPasswordValidator 
 };

--- a/src/middlewares/validators/user.dto.js
+++ b/src/middlewares/validators/user.dto.js
@@ -59,6 +59,27 @@ const loginValidator = [
   }
 ];
 
+// 회원탈퇴 검증
+const deleteUserValidator = [
+  // password: 필수, 8~64자
+  body("password")
+    .isString().withMessage("비밀번호는 문자열이어야 합니다.")
+    .isLength({ min: 8, max: 64 }).withMessage("비밀번호는 8~64자입니다."),
+
+  // 검증 결과 처리
+  (req, res, next) => {
+    const errors = validationResult(req);
+    if(!errors.isEmpty()) {
+      return res.status(400).json({
+        state: 400,
+        code: "VALIDATION_ERROR",
+        errors: errors.array().map(e => ({ field: e.path, message: e.msg }))
+      });
+    }
+    next();
+  }
+];
+
 // 비밀번호 변경 검증
 const changePasswordValidator = [
   // currentPassword: 필수, 8~64자
@@ -85,4 +106,9 @@ const changePasswordValidator = [
   }
 ];
 
-module.exports = { signupValidator , loginValidator, changePasswordValidator };
+module.exports = { 
+  signupValidator, 
+  loginValidator, 
+  deleteUserValidator, 
+  changePasswordValidator 
+};

--- a/src/middlewares/validators/user.dto.js
+++ b/src/middlewares/validators/user.dto.js
@@ -59,4 +59,30 @@ const loginValidator = [
   }
 ];
 
-module.exports = { signupValidator , loginValidator };
+// 비밀번호 변경 검증
+const changePasswordValidator = [
+  // currentPassword: 필수, 8~64자
+  body("currentPassword")
+    .isString().withMessage("비밀번호는 문자열이어야 합니다.")
+    .isLength({ min: 8, max: 64 }).withMessage("비밀번호는 8~64자입니다."),
+
+  // newPassword: 필수, 8~64자
+  body("newPassword")
+    .isString().withMessage("비밀번호는 문자열이어야 합니다.")
+    .isLength({ min: 8, max: 64 }).withMessage("비밀번호는 8~64자입니다."), 
+    
+  // 검증 결과 처리
+  (req, res, next) => {
+    const errors = validationResult(req);
+    if(!errors.isEmpty()) {
+      return res.status(400).json({
+        state: 400,
+        code: "VALIDATION_ERROR",
+        errors: errors.array().map(e => ({ field: e.path, message: e.msg }))
+      });
+    }
+    next();
+  }
+];
+
+module.exports = { signupValidator , loginValidator, changePasswordValidator };

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -28,6 +28,14 @@ const User = sequelize.define(
       type: DataTypes.STRING(500),
       allowNull: true,
     },
+    resetToken: {
+      type: DataTypes.STRING(128),
+      allowNull: true,
+    },
+    resetTokenExpiry: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
   },
   {
     tableName: "users",

--- a/src/routes/user.routes.js
+++ b/src/routes/user.routes.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const router = express.Router();
-const { signup, login, logout, deleteUser } = require("../controllers/user.controller");
+const { signup, login, logout, deleteUser, changePassword } = require("../controllers/user.controller");
 const { signupValidator, loginValidator } = require("../middlewares/validators/user.dto");
 const authMiddleware = require("../middlewares/auth.js");
 
@@ -16,5 +16,8 @@ router.post("/logout", authMiddleware, logout);
 
 // DELETE /api/users/delete -> 회원 탈퇴
 router.delete("/delete", authMiddleware, deleteUser);
+
+// PUT /api/users/change-password -> 비밀번호 변경 
+router.put("/change-password", authMiddleware, changePassword);
 
 module.exports = router;

--- a/src/routes/user.routes.js
+++ b/src/routes/user.routes.js
@@ -1,6 +1,9 @@
 const express = require("express");
 const router = express.Router();
-const { signup, login, logout, deleteUser, changePassword } = require("../controllers/user.controller");
+const { 
+    signup, login, logout, deleteUser, 
+    changePassword, forgotPassword, resetPassword 
+} = require("../controllers/user.controller");
 const { 
     signupValidator, 
     loginValidator,
@@ -23,5 +26,11 @@ router.delete("/delete", authMiddleware, deleteUserValidator, deleteUser);
 
 // PUT /api/users/change-password -> 비밀번호 변경 
 router.put("/change-password", authMiddleware, changePasswordValidator, changePassword);
+
+// POST /api/users/forgot-password -> 비밀번호 재설정 요청 (토큰 발급 & 메일 전송)
+router.post("/forgot-password", forgotPassword);
+
+// POST /api/users/reset-password -> 비밀번호 재설정
+router.post("/reset-password", resetPassword);
 
 module.exports = router;

--- a/src/routes/user.routes.js
+++ b/src/routes/user.routes.js
@@ -8,7 +8,9 @@ const {
     signupValidator, 
     loginValidator,
     deleteUserValidator,
-    changePasswordValidator
+    changePasswordValidator,
+    forgotPasswordValidator,
+    resetPasswordValidator
 } = require("../middlewares/validators/user.dto");
 const authMiddleware = require("../middlewares/auth.js");
 
@@ -28,9 +30,9 @@ router.delete("/delete", authMiddleware, deleteUserValidator, deleteUser);
 router.put("/change-password", authMiddleware, changePasswordValidator, changePassword);
 
 // POST /api/users/forgot-password -> 비밀번호 재설정 요청 (토큰 발급 & 메일 전송)
-router.post("/forgot-password", forgotPassword);
+router.post("/forgot-password", forgotPasswordValidator, forgotPassword);
 
 // POST /api/users/reset-password -> 비밀번호 재설정
-router.post("/reset-password", resetPassword);
+router.post("/reset-password", resetPasswordValidator, resetPassword);
 
 module.exports = router;

--- a/src/routes/user.routes.js
+++ b/src/routes/user.routes.js
@@ -1,7 +1,12 @@
 const express = require("express");
 const router = express.Router();
 const { signup, login, logout, deleteUser, changePassword } = require("../controllers/user.controller");
-const { signupValidator, loginValidator } = require("../middlewares/validators/user.dto");
+const { 
+    signupValidator, 
+    loginValidator,
+    deleteUserValidator,
+    changePasswordValidator
+} = require("../middlewares/validators/user.dto");
 const authMiddleware = require("../middlewares/auth.js");
 
 // POST /api/users/signup → 회원가입
@@ -10,14 +15,13 @@ router.post("/signup", signupValidator, signup);
 // POST /api/users/login -> 로그인
 router.post("/login", loginValidator, login);
 
-
 // POST /api/users/logout -> 로그아웃
 router.post("/logout", authMiddleware, logout);
 
 // DELETE /api/users/delete -> 회원 탈퇴
-router.delete("/delete", authMiddleware, deleteUser);
+router.delete("/delete", authMiddleware, deleteUserValidator, deleteUser);
 
 // PUT /api/users/change-password -> 비밀번호 변경 
-router.put("/change-password", authMiddleware, changePassword);
+router.put("/change-password", authMiddleware, changePasswordValidator, changePassword);
 
 module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -7,7 +7,7 @@ const PORT = process.env.PORT || 4000;
 (async () => {
   try {
     // 개발 단계에서는 DB 스키마 자동 동기화
-    await sequelize.sync(); // { alter: true } 옵션을 주면 컬럼 자동 업데이트
+    await sequelize.sync({ alter: true });
 
     // 서버 실행
     app.listen(PORT, () =>

--- a/src/utils/mailer.js
+++ b/src/utils/mailer.js
@@ -1,0 +1,31 @@
+const nodemailer = require("nodemailer");
+
+// Gmail SMTP 연결 (환경변수 사용)
+const transporter = nodemailer.createTransport({
+  service: "gmail",
+  auth: {
+    user: process.env.EMAIL_USER,  // Gmail 주소
+    pass: process.env.EMAIL_PASS   // 앱 비밀번호
+  },
+});
+
+// 이메일 전송 함수
+async function sendMail(to, subject, text, html) {
+  try {
+    const info = await transporter.sendMail({
+      from: `"MyAPP" <${process.env.EMAIL_USER}>`,  // ✅ 템플릿 문자열 수정
+      to,      // 받는 사람 이메일
+      subject, // 메일 제목
+      text,    // 텍스트 본문
+      html,    // HTML 본문
+    });
+
+    console.log("메일 전송 성공:", info.messageId);
+    return info;
+  } catch (err) {
+    console.error("메일 전송 실패:", err);
+    throw err;
+  }
+}
+
+module.exports = { sendMail };


### PR DESCRIPTION
# 작업 내용
-비밀번호 재설정 기능 구현
/api/users/forgot-password: 이메일로 비밀번호 재설정 링크 전송
/api/users/reset-password: 토큰 검증 후 새 비밀번호로 재설정
- User 모델 수정: resetToken, resetTokenExpiry 컬럼 추가
- 메일 발송 기능
Nodemailer과 Gmail SMTP 연동
utils/mailer.js 유틸 추가

# 확인 사항
- .env에 EMAIL_USER, EMAIL_PASS 설정 필요
- 비밀번호 재설정 메일 발송 확인
- Postman으로 /api/users/reset-password 호출 시 새 비밀번호 저장 및 로그인 가능 여부 확인
- 자동 동기화( sequelize.sync() )로 로컬 DB 반영