### PR TITLE
feat: 우클릭 메뉴 오픈 및 사용량 동작 구현

### DIFF
--- a/src/upload/components/content/FileMenu.jsx
+++ b/src/upload/components/content/FileMenu.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 function FileMenu({ 
     isVisible, 
@@ -11,6 +11,19 @@ function FileMenu({
     fileName 
 }) {
     const contextMenuRef = useRef(null);
+    const [isMobile, setIsMobile] = useState(false);
+
+    // 모바일 여부 확인
+    useEffect(() => {
+        const checkIsMobile = () => {
+            setIsMobile(window.innerWidth < 768);
+        };
+
+        checkIsMobile();
+        window.addEventListener('resize', checkIsMobile);
+
+        return () => window.removeEventListener('resize', checkIsMobile);
+    }, []);
 
     // 외부 클릭 시 메뉴 닫기
     useEffect(() => {
@@ -64,12 +77,17 @@ function FileMenu({
             >
                 다운로드
             </button>
-            <button 
-                onClick={onViewInfo}
-                className="w-full px-3 py-2 text-left text-[12px] text-[#34475C] hover:bg-[#F5F7FA] transition-colors"
-            >
-                정보 보기
-            </button>
+            
+            {/* 모바일에서만 정보 보기 메뉴 표시 */}
+            {isMobile && (
+                <button 
+                    onClick={onViewInfo}
+                    className="w-full px-3 py-2 text-left text-[12px] text-[#34475C] hover:bg-[#F5F7FA] transition-colors"
+                >
+                    정보 보기
+                </button>
+            )}
+            
             <button 
                 onClick={onRename}
                 className="w-full px-3 py-2 text-left text-[12px] text-[#34475C] hover:bg-[#F5F7FA] transition-colors"

--- a/src/upload/components/layout/Usage.jsx
+++ b/src/upload/components/layout/Usage.jsx
@@ -1,15 +1,65 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 function Usage() {
+    const [usageData, setUsageData] = useState({
+        used: 0,
+        total: 2,
+        percentage: 0
+    });
+    const [loading, setLoading] = useState(true);
+
+    // 백엔드에서 사용량 데이터 가져오기
+    useEffect(() => {
+        const fetchUsageData = async () => {
+            try {
+                setLoading(true);
+                // TODO: 실제 API 엔드포인트로 변경
+                const response = await fetch('/api/usage');
+                if (response.ok) {
+                    const data = await response.json();
+                    const percentage = (data.used / data.total) * 100;
+                    setUsageData({
+                        used: data.used,
+                        total: data.total,
+                        percentage: Math.min(percentage, 100) // 100% 초과 방지
+                    });
+                } else {
+                    // API 실패 시 기본값 사용
+                    console.warn('사용량 데이터를 가져올 수 없습니다. 기본값을 사용합니다.');
+                }
+            } catch (error) {
+                console.error('사용량 데이터 로딩 중 오류:', error);
+                // 오류 시 기본값 사용
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchUsageData();
+    }, []);
+
+    const formatBytes = (bytes) => {
+        if (bytes === 0) return '0GB';
+        const gb = bytes / (1024 * 1024 * 1024);
+        return `${gb.toFixed(1)}GB`;
+    };
+
     return (
         <div className="hide md:mr-3 md:mb-3 md:block md:w-auto md:h-18 bg-white border-[1px] border-[#DAE0E9] rounded-[15px] md:ml-3 p-4 flex flex-col justify-center">
             <div className="flex justify-between items-center mb-1">
                 <span className="text-[#2A2D41] font-medium text-[9pt]">사용량</span>
-                <span className="text-[#989AA9] text-[9pt]">0GB / 2GB</span>
+                <span className="text-[#989AA9] text-[9pt]">
+                    {loading ? '로딩 중...' : `${formatBytes(usageData.used)} / ${formatBytes(usageData.total)}`}
+                </span>
             </div>
             
             <div className="w-full h-1.5 bg-[#E5E7EB] rounded-full overflow-hidden">
-                <div className="h-full bg-gradient-to-r from-[#0D4CFF] to-[#33AAFF] rounded-full w-0"></div>
+                <div 
+                    className="h-full bg-gradient-to-r from-[#0D4CFF] to-[#33AAFF] rounded-full transition-all duration-500 ease-out"
+                    style={{ 
+                        width: loading ? '0%' : `${usageData.percentage}%` 
+                    }}
+                ></div>
             </div>
         </div>
     )

--- a/src/upload/components/layout/Usage.jsx
+++ b/src/upload/components/layout/Usage.jsx
@@ -13,10 +13,11 @@ function Usage() {
         const fetchUsageData = async () => {
             try {
                 setLoading(true);
-                // TODO: 실제 API 엔드포인트로 변경
                 const response = await fetch('/api/usage');
                 if (response.ok) {
-                    const data = await response.json();
+                    const result = await response.json();
+                    // 백엔드 응답 구조: { message, data: { total, used, free } }
+                    const { data } = result;
                     const percentage = (data.used / data.total) * 100;
                     setUsageData({
                         used: data.used,

--- a/src/upload/components/layout/Usage.jsx
+++ b/src/upload/components/layout/Usage.jsx
@@ -13,7 +13,7 @@ function Usage() {
         const fetchUsageData = async () => {
             try {
                 setLoading(true);
-                const response = await fetch('/api/usage');
+                const response = await fetch('/api/disk/usage');
                 if (response.ok) {
                     const result = await response.json();
                     // 백엔드 응답 구조: { message, data: { total, used, free } }


### PR DESCRIPTION
파일 메뉴 반응형 구현
- 모바일(768px 미만): 파일 꾹 눌렀을 때 4개 메뉴 표시 (다운로드, 정보 보기, 이름 바꾸기, 휴지통으로 이동)
- 데스크톱(768px 이상): 파일 우클릭 시 3개 메뉴 표시 (다운로드, 이름 바꾸기, 휴지통으로 이동)
- 화면 크기 변경 시 실시간 메뉴 업데이트
- "정보 보기" 메뉴는 모바일에서만 조건부 렌더링

사용량 컴포넌트 백엔드 연동
- /api/disk/usage 엔드포인트에서 사용량 데이터 가져오기
- 백엔드 API 응답 구조 { message, data: { total, used, free } }에 맞게 데이터 파싱 로직 수정
- 바이트 단위를 GB로 자동 변환하여 표시
- 사용량 퍼센티지에 따른 진행률 바 동적 업데이트
- 로딩 상태 및 에러 처리 구현